### PR TITLE
Fix moviepy imports

### DIFF
--- a/lotc/commands/download.py
+++ b/lotc/commands/download.py
@@ -7,7 +7,7 @@ import delegator
 import requests
 import rich_click as click
 from halo import Halo
-from moviepy.editor import VideoFileClip
+from moviepy import VideoFileClip
 from moviepy.video.io.ffmpeg_tools import ffmpeg_merge_video_audio
 
 from lotc.utils import (

--- a/lotc/utils.py
+++ b/lotc/utils.py
@@ -1,7 +1,7 @@
 import re
 from pathlib import Path
 
-from moviepy.editor import (
+from moviepy import (
     VideoFileClip,
     concatenate_videoclips,
 )


### PR DESCRIPTION
Currently using lotc from the command line is broken because it throws the following error:

  File "/home/s/.local/bin/lotc", line 5, in <module>
    from lotc.main import cli
  File "/home/s/.local/lib/python3.11/site-packages/lotc/main.py", line 1, in <module>
    from lotc.commands.download import download
  File "/home/s/.local/lib/python3.11/site-packages/lotc/commands/download.py", line 10, in <module>
    from moviepy.editor import VideoFileClip
ModuleNotFoundError: No module named 'moviepy.editor'

This is because moviepy has changed how imports work. moviepy.editor has been deprecated, now you just import with from moviepy import VideoFileClip. See https://pypi.org/project/moviepy/ and this thread: https://www.reddit.com/r/moviepy/comments/1gt95az/modulenotfounderror_no_module_named_moviepy/


